### PR TITLE
Make 2FA visible for non-admins with Edit User permissions

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -94,7 +94,8 @@ class Plugin extends CraftPlugin
          */
         Event::on(User::class, Element::EVENT_SET_TABLE_ATTRIBUTE_HTML, function (SetElementTableAttributeHtmlEvent $event) {
             $currentUser = Craft::$app->getUser()->getIdentity();
-            if ($event->attribute == 'hasTwoFactorAuthentication' && $currentUser->admin) {
+            if ($event->attribute == 'hasTwoFactorAuthentication' && $currentUser->can('editUsers')
+            && $currentUser->can('accessPlugin-two-factor-authentication')) {
                 /** @var User $user */
                 $user = $event->sender;
 
@@ -113,7 +114,8 @@ class Plugin extends CraftPlugin
          * Hook into the users cp page.
          */
         Craft::$app->view->hook('cp.users.edit.details', function (array &$context) {
-            if (Craft::$app->getUser()->getIsAdmin() && !$context['isNewUser']) {
+            $currentUser = Craft::$app->getUser()->getIdentity();
+            if($currentUser->can('editUsers') && $currentUser->can('accessPlugin-two-factor-authentication') && !$context['isNewUser']) {
                 /** @var User $user */
                 $user = $context['user'];
 


### PR DESCRIPTION
Allow users with Edit User permissions to see 2FA column in Users Table.

And allow them to disable 2FA on a user account page in the control panel.

Fixes a 500 error in the control panel.